### PR TITLE
PEP517 build system dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,5 @@ dmypy.json
 .pyre/
 
 .DS_store
+
+fastsim/*.c

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "cython", "numpy", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This should sort out the packaging issues as far as cython/numpy are concerned. Not sure about openmp.