### PR TITLE
CI config, and lints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,69 @@
+name: CI
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - run: pip install flake8
+      - run: flake8 .
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10.0-beta - 3.10.0']
+        runs-on: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: |
+          pip install -U pip wheel setuptools
+          pip install -r requirements.txt
+        name: Install dependencies
+      - run: |
+          pip install .
+        name: Install package
+      - run: pytest --verbose --benchmark-skip
+        name: Run tests
+      # benchmark once per OS to save time
+      - run: pytest --verbose --benchmark-only
+        if: matrix.python-version == '3.9'
+        name: Run benchmarks
+
+  deploy-package:
+    strategy:
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9']
+        runs-on: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ubuntu-18.04
+    needs: [lint, test]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - run: pip install build
+      - run: python -m build --sdist -o dist/ .
+        if: startsWith(matrix.runs_on, 'ubuntu') && python-version == '3.9'
+        name: build sdist
+      - run: python -m build --wheel -o dist/ .
+        name: build wheel
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_token }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
           pip install -r requirements.txt
         name: Install dependencies
       - run: |
-          pip install .
+          pip install -e .
         name: Install package
       - run: pytest --verbose --benchmark-skip
         name: Run tests
@@ -55,10 +55,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
       - run: pip install build
       - run: python -m build --sdist -o dist/ .
-        if: startsWith(matrix.runs_on, 'ubuntu') && python-version == '3.9'
+        if: startsWith(matrix.runs_on, 'ubuntu') && matrix.python-version == '3.9'
         name: build sdist
       - run: python -m build --wheel -o dist/ .
         name: build wheel

--- a/fastsim/__init__.py
+++ b/fastsim/__init__.py
@@ -1,1 +1,3 @@
-from .vertex import *
+from .vertex import vertex_similarity, _vertex_similarity_numpy  # noqa: F401
+
+__all__ = ["vertex_similarity"]

--- a/fastsim/_vertex_cython.pyx
+++ b/fastsim/_vertex_cython.pyx
@@ -22,14 +22,15 @@ def _vertex_similarity(int[:, ::1] mat, double C1=0.5, double C2=1):
     cdef double[:, ::1] result_view = result
 
     for idx1 in prange(N, nogil=True):
-        for idx2 in range(idx1, N):
-            val = 0
-            if idx1 == idx2:
-                for obs_idx in range(M):
-                    mx = mat[idx1, obs_idx]
-                    result_view[idx1, idx1] += vsim(mx, mx, C1, C2)
+        # diagonal/ self-hit case
+        for obs_idx in range(M):
+            mx = mat[idx1, obs_idx]
+            result_view[idx1, idx1] += vsim(mx, mx, C1, C2)
 
-                continue
+        # populate both triangles of the output matrix
+        # but only compute once for each
+        for idx2 in range(idx1 + 1, N):
+            val = 0
 
             for obs_idx in range(M):
                 mx = mat[idx1, obs_idx]

--- a/fastsim/vertex.py
+++ b/fastsim/vertex.py
@@ -3,7 +3,7 @@ import numpy as np
 from ._vertex_cython import _vertex_similarity
 
 
-__all__ = ['vertex_similarity']
+__all__ = ['vertex_similarity', "_vertex_similarity_numpy"]
 
 
 def vertex_similarity(mat, C1=0.5, C2=1):
@@ -43,7 +43,8 @@ def _vertex_similarity_numpy(mat, C1=0.5, C2=1):
         vecA = mat[i]
         for k in range(len(mat)):
             vecB = mat[k]
-            # np.minimum is much faster than np.min(np.vstack(vecA, vecB), axis=1) here
+            # np.minimum is much faster than
+            # np.min(np.vstack(vecA, vecB), axis=1) here
             this_max = np.maximum(vecA, vecB)
             this_min = np.minimum(vecA, vecB)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ pytest
 pytest-benchmark
 
 # dev
-mypy
 flake8


### PR DESCRIPTION
This CI config is largely complete. It passes on everything but MacOS, due to the clang issue noted in the readme. I'm not sure the best way to approach that here, but I'm pretty sure the macOS environments have brew, which is a good start. You can run conditional steps but you can't export environment variables in one step to be used in another. I guess we could have something like 

```yaml
# ci.yaml:jobs.test.steps
- if: startsWith(matrix.runs-on, "macos")
  run: |
    brew install llvm
    # ... set environment variables
    pip install -e .
- if "!(startsWith(matrix.runs-on, 'macos'))"
  run: pip install -e .
```

and the same in the deploy steps. The quoting around the negative conditional is, I believe, necessary to prevent the YAML parser throwing a fit around the bang.

Notes:

- The benchmarks run on every OS, but only 1 python version to save time
- I'm not sure whether the deploy config works, but either way will need a `pypi_token` environment variable in the repo settings 